### PR TITLE
Fix view shift when shuffling households

### DIFF
--- a/src/lib/components/HouseholdProfile.svelte
+++ b/src/lib/components/HouseholdProfile.svelte
@@ -229,7 +229,17 @@
       <div class="header-buttons">
         <button 
           class="action-button random-button" 
-          on:click={onRandomize}
+          on:click|preventDefault|stopPropagation={(e) => {
+            // Prevent any default scroll behavior
+            e.preventDefault();
+            e.stopPropagation();
+            
+            // Blur the button to prevent focus-related scrolling
+            e.currentTarget.blur();
+            
+            // Call the randomize function
+            onRandomize();
+          }}
           title="Pick a new random household"
         >
           🔀


### PR DESCRIPTION
## Summary
Fixes issue where clicking the shuffle button (🔀) causes the household profile box to jump or shift (especially on mobile), making the baseline selector inaccessible. Also updates household count formatting as requested.

## Technical Details

### Shuffle Stability Issues
The shuffle button was causing the view to center or jump, particularly on mobile devices. This was due to:
1. Browser scroll anchoring trying to maintain element positions
2. Focus management causing scroll-to-view behavior
3. Mobile-specific scroll snap behaviors

### Household Count Formatting
Updated the display of household counts in millions:
- Highest income group (>$1M): Shows one decimal place (e.g., "1.3 million")
- All other income groups: Rounds to nearest million (e.g., "59 million" instead of "59.2 million")

### Changes Made:

1. **Aggressive scroll prevention**:
   - Temporarily disable scroll anchoring during shuffle
   - Prevent default click behavior and blur button immediately
   - Force immediate scroll position restoration
   - Use requestAnimationFrame for follow-up restoration

2. **CSS improvements**:
   - Add `scroll-snap-type: none` to prevent snap behaviors
   - Add `scroll-snap-align: none` to text sections
   - Disable smooth scrolling on mobile during shuffle
   - Maintain minimum heights for layout stability

3. **Focus management**:
   - Store and restore active element with `preventScroll: true`
   - Blur shuffle button to prevent focus-based scrolling

4. **Formatting update**:
   - Modified `calculateSectionStats` to accept section ID
   - Apply different formatting based on income group

## Test Plan
1. Open the app on mobile device or mobile emulator
2. Scroll to a household profile
3. Position so baseline selector is visible at top
4. Click shuffle button (🔀) multiple times rapidly
5. Verify:
   - View doesn't jump or center
   - Baseline selector remains accessible
   - No scrolling occurs during shuffle
6. Check household counts:
   - Lower/middle/upper income groups show whole numbers (e.g., "59 million")
   - Highest income group shows one decimal (e.g., "1.3 million")

## Related Issues
Builds on shuffle fixes from PR #73 and baseline scroll fixes from PR #67.

🤖 Generated with [Claude Code](https://claude.ai/code)