### PR TITLE
Add (2026) to x-axis title

### DIFF
--- a/src/lib/components/ScatterPlot.svelte
+++ b/src/lib/components/ScatterPlot.svelte
@@ -397,7 +397,7 @@
       .style('font-size', isMobile ? '12px' : '16px')
       .style('font-weight', '400')
       .style('fill', COLORS.DARK_GRAY)
-      .text(isMobile ? 'Change in income →' : 'Change in net income →');
+      .text(isMobile ? 'Change in income (2026) →' : 'Change in net income (2026) →');
     
     g.append('text')
       .attr('transform', 'rotate(-90)')


### PR DESCRIPTION
## Summary
Adds "(2026)" to the x-axis title to clarify that the tax impact data is projected for the year 2026.

## Changes Made
- Desktop: "Change in net income →" becomes "Change in net income (2026) →"
- Mobile: "Change in income →" becomes "Change in income (2026) →"

## Visual Example
Before: `Change in net income →`
After: `Change in net income (2026) →`

This helps users understand that the household tax impacts shown are projections for 2026.

🤖 Generated with [Claude Code](https://claude.ai/code)