### PR TITLE
Add PolicyEngine shell header to OBBBA explorer

### DIFF
--- a/app/PolicyEngineHeader.jsx
+++ b/app/PolicyEngineHeader.jsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Header } from '@policyengine/ui-kit';
+
+const navItems = [
+  { label: 'Research', href: 'https://policyengine.org/us/research' },
+  { label: 'Model', href: 'https://policyengine.org/us/model' },
+  { label: 'API', href: 'https://policyengine.org/us/api' },
+  {
+    label: 'About',
+    href: 'https://policyengine.org/us/team',
+    children: [
+      { label: 'Team', href: 'https://policyengine.org/us/team' },
+      { label: 'Supporters', href: 'https://policyengine.org/us/supporters' }
+    ]
+  },
+  { label: 'Donate', href: 'https://policyengine.org/us/donate' }
+];
+
+const countries = [
+  { id: 'us', label: 'United States' },
+  { id: 'uk', label: 'United Kingdom' }
+];
+
+export default function PolicyEngineHeader() {
+  return (
+    <Header
+      navItems={navItems}
+      countries={countries}
+      currentCountry="us"
+      logoHref="https://policyengine.org/us"
+      onCountryChange={(countryId) => {
+        window.location.href = `https://policyengine.org/${countryId}`;
+      }}
+    />
+  );
+}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import PolicyEngineHeader from './PolicyEngineHeader';
 
 export const metadata = {
   title: 'OBBBA Household Explorer',
@@ -11,7 +12,10 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <PolicyEngineHeader />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,4 +1,5 @@
 :root {
+  --pe-site-header-height: var(--spacing-header, 58px);
   --pe-teal: #319795;
   --pe-teal-dark: #267875;
   --pe-ink: #1f2937;
@@ -36,7 +37,7 @@ button {
 
 .topbar {
   position: sticky;
-  top: 0;
+  top: var(--pe-site-header-height);
   z-index: 10;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- Adds a PolicyEngine UI Kit site header to the Next layout.
- Offsets the app's sticky explorer toolbar so it remains below the sticky site header.

## Validation
- `npm run format:check`
- `npm run build`
- Local Playwright check: `http://localhost:3102/us/obbba-household-explorer/` rendered the PolicyEngine header and loaded household explorer data.