### PR TITLE
Guard the PolicyEngine site shell in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,20 @@ jobs:
         name: build-files
         path: build/
         retention-days: 1
+
+  shell-check:
+    name: Layout carries the PolicyEngine site shell
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Assert the site shell stays in the root layout
+      # The app is client-rendered (adapter-static SPA fallback), so the
+      # built HTML cannot be grepped; assert on the layout source instead.
+      run: |
+        layout=src/routes/+layout.svelte
+        for needle in "label: 'Research'" "label: 'Model'" "label: 'API'" "label: 'Donate'" "label: 'About us'" "label: 'Developer tools'" "label: 'Privacy policy'" "label: 'Terms and conditions'" "policyengine-white.svg" "pe-shell-header" "pe-shell-site-footer"; do
+          grep -qF -- "$needle" "$layout" || { echo "MISSING from $layout: $needle"; exit 1; }
+        done
+        echo "Site shell present in the root layout."


### PR DESCRIPTION
Follow-up to the site-shell rollout (policyengine-app-v2#1148): CI now asserts the PolicyEngine brand, the Research / Model / API / Donate nav labels, and the five site footer links stay present, so a change that drops the shell fails the PR instead of surfacing a day later in the production zone-shell audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)